### PR TITLE
Update targets and fix issue with contexts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:3.1.1'
         classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
 
     }
@@ -13,6 +14,10 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
+        maven {
+            url 'https://maven.google.com/'
+        }
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 11 17:06:21 MSK 2016
+#Thu Mar 29 12:17:14 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/paper-onboarding-fragment-example/build.gradle
+++ b/paper-onboarding-fragment-example/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.ramotion.paperonboarding.examples.fragment"
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 27
         versionCode 2
         versionName '1.1.0'
     }
@@ -20,8 +20,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile project(path: ':paper-onboarding')
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation project(path: ':paper-onboarding')
 }

--- a/paper-onboarding-simple-example/build.gradle
+++ b/paper-onboarding-simple-example/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.ramotion.paperonboarding.examples.simple"
@@ -20,9 +20,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile project(':paper-onboarding')
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:support-v4:23.4.0'
+    testImplementation 'junit:junit:4.12'
+    implementation project(':paper-onboarding')
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:support-core-ui:27.1.1'
 }

--- a/paper-onboarding/build.gradle
+++ b/paper-onboarding/build.gradle
@@ -7,11 +7,11 @@ group = 'com.ramotion.paperonboarding'
 version = '1.1.1'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 27
         versionCode 3
         versionName version
     }
@@ -38,9 +38,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    testImplementation 'junit:junit:4.12'
+    api 'com.android.support:appcompat-v7:27.1.1'
 }
 
 modifyPom {

--- a/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingFragment.java
+++ b/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingFragment.java
@@ -1,6 +1,7 @@
 package com.ramotion.paperonboarding;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -38,17 +39,18 @@ public class PaperOnboardingFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
+            //noinspection unchecked
             mElements = (ArrayList<PaperOnboardingPage>) getArguments().get(ELEMENTS_PARAM);
         }
     }
 
     @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.onboarding_main_layout, container, false);
 
         // create engine for onboarding element
-        PaperOnboardingEngine mPaperOnboardingEngine = new PaperOnboardingEngine(view.findViewById(R.id.onboardingRootView), mElements, getActivity().getApplicationContext());
+        PaperOnboardingEngine mPaperOnboardingEngine = new PaperOnboardingEngine(view.findViewById(R.id.onboardingRootView), mElements, getActivity());
         // set listeners
         mPaperOnboardingEngine.setOnChangeListener(mOnChangeListener);
         mPaperOnboardingEngine.setOnLeftOutListener(mOnLeftOutListener);

--- a/paper-onboarding/src/main/res/layout/onboarding_text_content_layout.xml
+++ b/paper-onboarding/src/main/res/layout/onboarding_text_content_layout.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:orientation="vertical">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         android:layout_marginBottom="10dp"
-        android:text="Content title"
+        tools:text="Content title"
         android:textAlignment="center"
         android:textSize="32sp"
         android:textStyle="bold" />
@@ -18,7 +19,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:text="Content text"
+        tools:text="Content text"
         android:textAlignment="center"
         android:textSize="16sp" />
 


### PR DESCRIPTION
Hello,
I was using the library and found out that on some devices (in particular with Android 5-5.1.1 there are some issues reading the context.

The OnBoardingEngine is using the ApplicationContext instead of the ActivityContext in which it is added. This issue is subdule to find and see. You have it if, for example have a main theme which is Dark, and the activity holding the onboarding is a Light theme. If you have so, the texts in the carousel is white, even if in a light theme!
This pull request (in particular the commit 
https://github.com/Ramotion/paper-onboarding-android/commit/cd500e60589127b1f30c22e4e84c91aacef32942 that uses the ActivityContext instead.