### PR TITLE
Fix pager clipped when having a large number of pages

### DIFF
--- a/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingEngine.java
+++ b/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingEngine.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.os.Build;
 import android.view.Gravity;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
@@ -15,6 +16,7 @@ import android.view.ViewTreeObserver;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.FrameLayout;
+import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
@@ -46,6 +48,7 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
 
     private final RelativeLayout mContentRootLayout;
     private final LinearLayout mContentCenteredContainer;
+    private final HorizontalScrollView mPagerLayoutContainer;
 
     // application context
     private final Context mAppContext;
@@ -87,6 +90,26 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
 
         mContentRootLayout = (RelativeLayout) mRootLayout.getChildAt(1);
         mContentCenteredContainer = (LinearLayout) mContentRootLayout.getChildAt(0);
+
+        /* Disable scrolling on scroll view but enable swipe */
+        mPagerLayoutContainer = rootLayout.findViewById(R.id.onboardingPagerLayoutContainer);
+        mPagerLayoutContainer.setOnTouchListener(new OnSwipeListener(mAppContext) {
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                super.onTouch(v, event);
+                return true;
+            }
+
+            @Override
+            public void onSwipeRight() {
+                toggleContent(true);
+            }
+
+            @Override
+            public void onSwipeLeft() {
+                toggleContent(false);
+            }
+        });
 
         this.dpToPixelsScaleFactor = this.mAppContext.getResources().getDisplayMetrics().density;
 
@@ -144,7 +167,7 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
         int pagerActiveElemCenterPosX = mPagerElementActiveSize / 2
                 + newActiveElement * mPagerElementLeftMargin
                 + (newActiveElement - 1) * (mPagerElementNormalSize + mPagerElementRightMargin);
-        return mRootLayout.getWidth() / 2 - pagerActiveElemCenterPosX;
+        return mPagerLayoutContainer.getWidth() / 2 - pagerActiveElemCenterPosX;
     }
 
     /**

--- a/paper-onboarding/src/main/res/layout/onboarding_main_layout.xml
+++ b/paper-onboarding/src/main/res/layout/onboarding_main_layout.xml
@@ -52,16 +52,27 @@
     </RelativeLayout>
 
     <!-- PAGER ICONS CONTAINER -->
-    <LinearLayout
-        android:id="@+id/onboardingPagerIconsContainer"
-        android:layout_width="wrap_content"
-        android:layout_height="40dp"
+    <HorizontalScrollView
+        android:id="@+id/onboardingPagerLayoutContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:layout_gravity="center_horizontal|bottom"
-        android:layout_marginBottom="25dp"
-        android:baselineAligned="false"
-        android:gravity="center_vertical"
-        android:orientation="horizontal" />
+        android:scrollbars="none"
+        android:layout_marginEnd="54dp"
+        android:layout_marginRight="54dp"
+        android:layout_marginStart="54dp"
+        android:layout_marginLeft="54dp">
+        <LinearLayout
+            android:id="@+id/onboardingPagerIconsContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:layout_gravity="center_horizontal|bottom"
+            android:layout_marginBottom="25dp"
+            android:baselineAligned="false"
+            android:gravity="center_vertical"
+            android:orientation="horizontal" />
+    </HorizontalScrollView>
+
 
 
 </RelativeLayout>


### PR DESCRIPTION
I noticed the bottom pager icons were clipped when there were, in my case, more than 10 pages.
This is due to android not allowing a layout to be larger than the screen.
I put the pager layout in a HorizontalScrollView to patch the problem.
The HorizontalScrollView is not scrollable and a swipe on it has the same behavior as a swipe on he rest of the screen