### PR TITLE
Add UI buttons to the pages

### DIFF
--- a/paper-onboarding-fragment-example/src/main/java/com/ramotion/paperonboarding/examples/fragment/FragmentsActivity.java
+++ b/paper-onboarding-fragment-example/src/main/java/com/ramotion/paperonboarding/examples/fragment/FragmentsActivity.java
@@ -43,12 +43,41 @@ public class FragmentsActivity extends AppCompatActivity {
 
     private ArrayList<PaperOnboardingPage> getDataForOnboarding() {
         // prepare data
-        PaperOnboardingPage scr1 = new PaperOnboardingPage("Hotels", "All hotels and hostels are sorted by hospitality rating",
-                Color.parseColor("#678FB4"), R.drawable.hotels, R.drawable.key);
-        PaperOnboardingPage scr2 = new PaperOnboardingPage("Banks", "We carefully verify all banks before add them into the app",
-                Color.parseColor("#65B0B4"), R.drawable.banks, R.drawable.wallet);
-        PaperOnboardingPage scr3 = new PaperOnboardingPage("Stores", "All local stores are categorized for your convenience",
-                Color.parseColor("#9B90BC"), R.drawable.stores, R.drawable.shopping_cart);
+        PaperOnboardingPage scr1;
+        PaperOnboardingPage.Builder builder = new PaperOnboardingPage.Builder("Hotels", "All hotels and hostels are sorted by hospitality rating")
+                .setSkipText("Skip")
+                .setShowSkipButton(true)
+                .setShowNextButton(true)
+                .setShowPreviousButton(true)
+                .setContentIconRes(R.drawable.hotels)
+                .setBgColor(Color.parseColor("#678FB4"))
+                .setBottomBarIconRes(R.drawable.key);
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            builder.setNextButtonColor(Color.RED);
+        }
+        scr1 = builder.create();
+
+
+        PaperOnboardingPage scr2 = new PaperOnboardingPage.Builder("Banks", "We carefully verify all banks before add them into the app")
+                .setSkipText("Skip")
+                .setShowSkipButton(true)
+                .setShowNextButton(true)
+                .setShowPreviousButton(true)
+                .setContentIconRes(R.drawable.banks)
+                .setBgColor(Color.parseColor("#65B0B4"))
+                .setBottomBarIconRes(R.drawable.wallet)
+                .create();
+
+        PaperOnboardingPage scr3 = new PaperOnboardingPage.Builder("Stores", "All local stores are categorized for your convenience")
+                .setSkipText("Skip")
+                .setShowSkipButton(true)
+                .setShowNextButton(true)
+                .setShowPreviousButton(true)
+                .setContentIconRes(R.drawable.stores)
+                .setBgColor(Color.parseColor("#9B90BC"))
+                .setBottomBarIconRes(R.drawable.shopping_cart)
+                .create();
 
         ArrayList<PaperOnboardingPage> elements = new ArrayList<>();
         elements.add(scr1);

--- a/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingPage.java
+++ b/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingPage.java
@@ -1,5 +1,10 @@
 package com.ramotion.paperonboarding;
 
+import android.graphics.Color;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
 import java.io.Serializable;
 
 /**
@@ -13,6 +18,123 @@ public class PaperOnboardingPage implements Serializable {
     private int contentIconRes;
     private int bottomBarIconRes;
 
+    private boolean showSkipButton;
+    private boolean showNextButton;
+    private boolean showPreviousButton;
+    private String skipText;
+
+    private int previousButtonColor;
+    private int nextButtonColor;
+
+    public static class Builder {
+        private String titleText;
+        private String descriptionText;
+        private int bgColor;
+        private int contentIconRes;
+        private int bottomBarIconRes;
+
+        private boolean showSkipButton;
+        private boolean showNextButton;
+        private boolean showPreviousButton;
+        private String skipText;
+
+        private int previousButtonColor;
+        private int nextButtonColor;
+
+
+        public Builder() {
+            init();
+        }
+
+        public Builder(String titleText, String descriptionText) {
+            init();
+            this.titleText = titleText;
+            this.descriptionText = descriptionText;
+        }
+
+        private void init() {
+            titleText = "";
+            descriptionText = "";
+            bgColor = Color.TRANSPARENT;
+            contentIconRes = -1;
+            bottomBarIconRes = -1;
+            showNextButton = false;
+            showSkipButton = false;
+            showPreviousButton = false;
+            skipText = "";
+            previousButtonColor = Color.BLACK;
+            nextButtonColor = Color.BLACK;
+        }
+
+        public Builder setTitleText(String titleText) {
+            this.titleText = titleText;
+            return this;
+        }
+
+        public Builder setDescriptionText(String descriptionText) {
+            this.descriptionText = descriptionText;
+            return this;
+        }
+
+        public Builder setBgColor(int bgColor) {
+            this.bgColor = bgColor;
+            return this;
+        }
+
+        public Builder setContentIconRes(int contentIconRes) {
+            this.contentIconRes = contentIconRes;
+            return this;
+        }
+
+        public Builder setBottomBarIconRes(int bottomBarIconRes) {
+            this.bottomBarIconRes = bottomBarIconRes;
+            return this;
+        }
+
+        public Builder setShowSkipButton(boolean showSkipButton) {
+            this.showSkipButton = showSkipButton;
+            return this;
+        }
+
+        public Builder setShowNextButton(boolean showNextButton) {
+            this.showNextButton = showNextButton;
+            return this;
+        }
+
+        public Builder setShowPreviousButton(boolean showPreviousButton) {
+            this.showPreviousButton = showPreviousButton;
+            return this;
+        }
+
+        public Builder setSkipText(String skipText) {
+            this.skipText = skipText;
+            return this;
+        }
+
+        @RequiresApi(21)
+        public Builder setPreviousButtonColor(int color) {
+            this.previousButtonColor = color;
+            return this;
+        }
+
+        @RequiresApi(21)
+        public Builder setNextButtonColor(int color) {
+            this.nextButtonColor = color;
+            return this;
+        }
+
+        public PaperOnboardingPage create() {
+            PaperOnboardingPage res = new PaperOnboardingPage(titleText, descriptionText, bgColor, contentIconRes, bottomBarIconRes);
+            res.setShowNextButton(showNextButton);
+            res.setShowSkipButton(showSkipButton);
+            res.setShowPreviousButton(showPreviousButton);
+            res.setSkipText(skipText);
+            res.setNextButtonColor(nextButtonColor);
+            res.setPreviousButtonColor(previousButtonColor);
+            return res;
+        }
+    }
+
     public PaperOnboardingPage() {
     }
 
@@ -22,6 +144,9 @@ public class PaperOnboardingPage implements Serializable {
         this.bottomBarIconRes = bottomBarIconRes;
         this.descriptionText = descriptionText;
         this.titleText = titleText;
+        this.showSkipButton = false;
+        this.showNextButton = false;
+        this.showPreviousButton = false;
     }
 
     public String getTitleText() {
@@ -64,6 +189,55 @@ public class PaperOnboardingPage implements Serializable {
         this.bgColor = bgColor;
     }
 
+
+    public boolean getShowSkipButton() {
+        return showSkipButton;
+    }
+
+    public void setShowSkipButton(boolean showSkipButton) {
+        this.showSkipButton = showSkipButton;
+    }
+
+    public boolean getShowNextButton() {
+        return showNextButton;
+    }
+
+    public void setShowNextButton(boolean showNextButton) {
+        this.showNextButton = showNextButton;
+    }
+
+    public boolean getShowPreviousButton() {
+        return showPreviousButton;
+    }
+
+    public void setShowPreviousButton(boolean showPreviousButton) {
+        this.showPreviousButton = showPreviousButton;
+    }
+
+    public int getPreviousButtonColor() {
+        return this.previousButtonColor;
+    }
+
+    public void setPreviousButtonColor(int color) {
+        this.previousButtonColor = color;
+    }
+
+    public int getNextButtonColor() {
+        return this.nextButtonColor;
+    }
+
+    public void setNextButtonColor(int color) {
+        this.nextButtonColor = color;
+    }
+
+    public String getSkipText() {
+        return skipText;
+    }
+
+    public void setSkipText(String skipText) {
+        this.skipText = skipText;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -74,7 +248,13 @@ public class PaperOnboardingPage implements Serializable {
         if (bgColor != that.bgColor) return false;
         if (contentIconRes != that.contentIconRes) return false;
         if (bottomBarIconRes != that.bottomBarIconRes) return false;
+        if (showNextButton != that.showNextButton) return false;
+        if (showPreviousButton != that.showPreviousButton) return false;
+        if (showSkipButton != that.showSkipButton) return false;
+
         if (titleText != null ? !titleText.equals(that.titleText) : that.titleText != null)
+            return false;
+        if (skipText != null ? !skipText.equals(that.skipText) : that.skipText != null)
             return false;
         return descriptionText != null ? descriptionText.equals(that.descriptionText) : that.descriptionText == null;
 
@@ -84,11 +264,18 @@ public class PaperOnboardingPage implements Serializable {
     public int hashCode() {
         int result = titleText != null ? titleText.hashCode() : 0;
         result = 31 * result + (descriptionText != null ? descriptionText.hashCode() : 0);
+        result = 31 * result + (skipText != null ? skipText.hashCode() : 0);
         result = 31 * result + bgColor;
         result = 31 * result + contentIconRes;
         result = 31 * result + bottomBarIconRes;
+        result = 31 * result + bottomBarIconRes;
+        result = 31 * result + (showSkipButton? 1: 0);
+        result = 31 * result + (showPreviousButton? 1: 0);
+        result = 31 * result + (showNextButton? 1: 0);
         return result;
     }
+
+
 
     @Override
     public String toString() {

--- a/paper-onboarding/src/main/res/drawable/onboarding_button_next_icon.xml
+++ b/paper-onboarding/src/main/res/drawable/onboarding_button_next_icon.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M6.23,20.23l1.77,1.77l10,-10l-10,-10l-1.77,1.77l8.23,8.23z"/>
+</vector>

--- a/paper-onboarding/src/main/res/drawable/onboarding_button_previous_icon.xml
+++ b/paper-onboarding/src/main/res/drawable/onboarding_button_previous_icon.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M11.67,3.87L9.9,2.1 0,12l9.9,9.9 1.77,-1.77L3.54,12z"/>
+</vector>

--- a/paper-onboarding/src/main/res/layout-v21/onboarding_button_layout.xml
+++ b/paper-onboarding/src/main/res/layout-v21/onboarding_button_layout.xml
@@ -1,0 +1,35 @@
+<RelativeLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/transparent"
+    android:layout_marginBottom="25dp"
+    android:layout_marginTop="10dp"
+    android:layout_marginStart="15dp"
+    android:layout_marginLeft="15dp"
+    android:layout_marginEnd="15dp"
+    android:layout_marginRight="15dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <Button
+        android:id="@+id/onboardingButtonSkip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:background="?android:attr/selectableItemBackgroundBorderless"/>
+    <ImageButton
+        android:id="@+id/onboardingButtonNext"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentEnd="true"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/onboarding_button_next_icon"/>
+    <ImageButton
+        android:id="@+id/onboardingButtonPrevious"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentStart="true"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/onboarding_button_previous_icon" />
+</RelativeLayout>

--- a/paper-onboarding/src/main/res/layout/onboarding_button_layout.xml
+++ b/paper-onboarding/src/main/res/layout/onboarding_button_layout.xml
@@ -1,0 +1,40 @@
+<RelativeLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/transparent"
+    android:layout_marginBottom="25dp"
+    android:layout_marginTop="10dp"
+    android:layout_marginStart="15dp"
+    android:layout_marginLeft="15dp"
+    android:layout_marginEnd="15dp"
+    android:layout_marginRight="15dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <Button
+        android:id="@+id/onboardingButtonSkip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:background="?android:attr/selectableItemBackground"
+        android:layout_alignParentRight="true" />
+
+    <ImageButton
+        android:id="@+id/onboardingButtonNext"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentEnd="true"
+        android:background="?android:attr/selectableItemBackground"
+        android:layout_alignParentRight="true"
+        android:src="@drawable/onboarding_button_next_icon"/>
+
+    <ImageButton
+        android:id="@+id/onboardingButtonPrevious"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentStart="true"
+        android:background="?android:attr/selectableItemBackground"
+        android:layout_alignParentLeft="true"
+        android:src="@drawable/onboarding_button_previous_icon"/>
+</RelativeLayout>

--- a/paper-onboarding/src/main/res/layout/onboarding_main_layout.xml
+++ b/paper-onboarding/src/main/res/layout/onboarding_main_layout.xml
@@ -63,5 +63,14 @@
         android:gravity="center_vertical"
         android:orientation="horizontal" />
 
+    <!--  BUTTONS CONTAINER  -->
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/transparent"
+        android:id="@+id/onboardingButtonContainer"
+        android:clipChildren="false"
+        android:clipToPadding="false" />
+
 
 </RelativeLayout>


### PR DESCRIPTION
I added 3 buttons (that can be shown or not):
- A skip button that automatically calls the `onRightOut` listener
- A previous button that goes back one page
- A next button that goes forward one page

The text of the skip button is customizable
The next and previous buttons are ImageButtons with an arrow drawable. Its color can be changed in API 21+

I also added a builder for readability purposes.

These changes are compatible with the previous version of the library.