### PR TITLE
Fix for issue #58

### DIFF
--- a/paper-onboarding-fragment-example/src/main/AndroidManifest.xml
+++ b/paper-onboarding-fragment-example/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ramotion.paperonboarding.examples.fragment">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/paper-onboarding-fragment-example/src/main/java/com/ramotion/paperonboarding/examples/fragment/FragmentsActivity.java
+++ b/paper-onboarding-fragment-example/src/main/java/com/ramotion/paperonboarding/examples/fragment/FragmentsActivity.java
@@ -3,16 +3,16 @@ package com.ramotion.paperonboarding.examples.fragment;
 import android.graphics.Color;
 import android.os.Bundle;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
+
 import com.ramotion.paperonboarding.PaperOnboardingFragment;
 import com.ramotion.paperonboarding.PaperOnboardingPage;
 import com.ramotion.paperonboarding.listeners.PaperOnboardingOnRightOutListener;
 
 import java.util.ArrayList;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentTransaction;
 
 public class FragmentsActivity extends AppCompatActivity {
 

--- a/paper-onboarding-simple-example/src/main/AndroidManifest.xml
+++ b/paper-onboarding-simple-example/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ramotion.paperonboarding.examples.simple">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/paper-onboarding/build.gradle
+++ b/paper-onboarding/build.gradle
@@ -40,6 +40,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.squareup.picasso:picasso:2.71828'
     testImplementation 'junit:junit:4.12'
 }
 

--- a/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingEngine.java
+++ b/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingEngine.java
@@ -5,7 +5,9 @@ import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
 import android.content.Context;
+import android.graphics.Typeface;
 import android.os.Build;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -26,6 +28,7 @@ import com.ramotion.paperonboarding.listeners.PaperOnboardingOnChangeListener;
 import com.ramotion.paperonboarding.listeners.PaperOnboardingOnLeftOutListener;
 import com.ramotion.paperonboarding.listeners.PaperOnboardingOnRightOutListener;
 import com.ramotion.paperonboarding.utils.PaperOnboardingEngineDefaults;
+import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 
@@ -468,8 +471,56 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
         ViewGroup contentTextView = (ViewGroup) vi.inflate(R.layout.onboarding_text_content_layout, mContentTextContainer, false);
         TextView contentTitle = (TextView) contentTextView.getChildAt(0);
         contentTitle.setText(PaperOnboardingPage.getTitleText());
+
+        if (PaperOnboardingPage.getTitleTextColor() != 0) {
+            contentTitle.setTextColor(PaperOnboardingPage.getTitleTextColor());
+        }
+
+        if (PaperOnboardingPage.getTitleTextSize() != 0) {
+            contentTitle.setTextSize(TypedValue.COMPLEX_UNIT_SP, PaperOnboardingPage.getTitleTextSize());
+        }
+
+        switch (PaperOnboardingPage.getTitleTextStyle()) {
+            case NORMAL:
+                contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.NORMAL);
+                break;
+            case ITALIC:
+                contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.ITALIC);
+                break;
+            case BOLD_ITALIC:
+                contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.BOLD_ITALIC);
+                break;
+            case BOLD:
+            default:
+                contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.BOLD);
+        }
+
         TextView contentText = (TextView) contentTextView.getChildAt(1);
         contentText.setText(PaperOnboardingPage.getDescriptionText());
+
+        if (PaperOnboardingPage.getDescriptionTextColor() != 0) {
+            contentText.setTextColor(PaperOnboardingPage.getDescriptionTextColor());
+        }
+
+        if (PaperOnboardingPage.getDescriptionTextSize() != 0) {
+            contentText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PaperOnboardingPage.getDescriptionTextSize());
+        }
+
+        switch (PaperOnboardingPage.getDescriptionTextStyle()) {
+            case NORMAL:
+                contentText.setTypeface(contentTitle.getTypeface(), Typeface.NORMAL);
+                break;
+            case ITALIC:
+                contentText.setTypeface(contentTitle.getTypeface(), Typeface.ITALIC);
+                break;
+            case BOLD_ITALIC:
+                contentText.setTypeface(contentTitle.getTypeface(), Typeface.BOLD_ITALIC);
+                break;
+            case BOLD:
+            default:
+                contentText.setTypeface(contentTitle.getTypeface(), Typeface.BOLD);
+        }
+
         return contentTextView;
     }
 
@@ -479,7 +530,22 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
      */
     protected ImageView createContentIconView(PaperOnboardingPage PaperOnboardingPage) {
         ImageView contentIcon = new ImageView(mAppContext);
-        contentIcon.setImageResource(PaperOnboardingPage.getContentIconRes());
+
+        if (PaperOnboardingPage.getImageUrl() != null) {
+            if (PaperOnboardingPage.getImageUrl().startsWith("http")) {
+                if (PaperOnboardingPage.getImageHeight() != 0 && PaperOnboardingPage.getImageWidth() != 0) {
+                    Picasso.get()
+                            .load(PaperOnboardingPage.getImageUrl())
+                            .resize(dpToPixels(PaperOnboardingPage.getImageWidth()), dpToPixels(PaperOnboardingPage.getImageHeight()))
+                            .into(contentIcon);
+                } else {
+                    Picasso.get().load(PaperOnboardingPage.getImageUrl()).into(contentIcon);
+                }
+            }
+        } else {
+            contentIcon.setImageResource(PaperOnboardingPage.getContentIconRes());
+        }
+
         FrameLayout.LayoutParams iconLP = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         iconLP.gravity = Gravity.CENTER;
         contentIcon.setLayoutParams(iconLP);

--- a/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingEngine.java
+++ b/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingEngine.java
@@ -54,7 +54,7 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
     private final Context mAppContext;
 
     // state variables
-    private ArrayList<PaperOnboardingPage> mElements = new ArrayList<>();
+    private final ArrayList<PaperOnboardingPage> mElements = new ArrayList<>();
     private int mActiveElementIndex = 0;
 
     // params for Pager position calculations, virtually final, but initializes in onGlobalLayoutListener
@@ -83,10 +83,10 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
         this.mAppContext = appContext.getApplicationContext();
 
         mRootLayout = (RelativeLayout) rootLayout;
-        mContentTextContainer = (FrameLayout) rootLayout.findViewById(R.id.onboardingContentTextContainer);
-        mContentIconContainer = (FrameLayout) rootLayout.findViewById(R.id.onboardingContentIconContainer);
-        mBackgroundContainer = (FrameLayout) rootLayout.findViewById(R.id.onboardingBackgroundContainer);
-        mPagerIconsContainer = (LinearLayout) rootLayout.findViewById(R.id.onboardingPagerIconsContainer);
+        mContentTextContainer = rootLayout.findViewById(R.id.onboardingContentTextContainer);
+        mContentIconContainer = rootLayout.findViewById(R.id.onboardingContentIconContainer);
+        mBackgroundContainer = rootLayout.findViewById(R.id.onboardingBackgroundContainer);
+        mPagerIconsContainer = rootLayout.findViewById(R.id.onboardingPagerIconsContainer);
 
         mContentRootLayout = (RelativeLayout) mRootLayout.getChildAt(1);
         mContentCenteredContainer = (LinearLayout) mContentRootLayout.getChildAt(0);
@@ -105,7 +105,6 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
             public void onSwipeRight() {
                 toggleContent(true);
             }
-
         });
 
         mRootLayout.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
@@ -127,7 +126,7 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
                 mPagerElementRightMargin = layoutParams.rightMargin;
 
                 mPagerIconsContainer.setX(calculateNewPagerPosition(0));
-                mContentCenteredContainer.setY((mContentRootLayout.getHeight() - mContentCenteredContainer.getHeight()) / 2);
+                mContentCenteredContainer.setY((mContentRootLayout.getHeight() - mContentCenteredContainer.getHeight()) >> 1);
 
             }
         });
@@ -480,19 +479,23 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
             contentTitle.setTextSize(TypedValue.COMPLEX_UNIT_SP, PaperOnboardingPage.getTitleTextSize());
         }
 
-        switch (PaperOnboardingPage.getTitleTextStyle()) {
-            case NORMAL:
-                contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.NORMAL);
-                break;
-            case ITALIC:
-                contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.ITALIC);
-                break;
-            case BOLD_ITALIC:
-                contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.BOLD_ITALIC);
-                break;
-            case BOLD:
-            default:
-                contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.BOLD);
+        if (PaperOnboardingPage.getTitleTextStyle() != null) {
+            switch (PaperOnboardingPage.getTitleTextStyle()) {
+                case NORMAL:
+                    contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.NORMAL);
+                    break;
+                case ITALIC:
+                    contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.ITALIC);
+                    break;
+                case BOLD_ITALIC:
+                    contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.BOLD_ITALIC);
+                    break;
+                case BOLD:
+                default:
+                    contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.BOLD);
+            }
+        } else {
+            contentTitle.setTypeface(contentTitle.getTypeface(), Typeface.BOLD);
         }
 
         TextView contentText = (TextView) contentTextView.getChildAt(1);
@@ -506,21 +509,24 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
             contentText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PaperOnboardingPage.getDescriptionTextSize());
         }
 
-        switch (PaperOnboardingPage.getDescriptionTextStyle()) {
-            case NORMAL:
-                contentText.setTypeface(contentTitle.getTypeface(), Typeface.NORMAL);
-                break;
-            case ITALIC:
-                contentText.setTypeface(contentTitle.getTypeface(), Typeface.ITALIC);
-                break;
-            case BOLD_ITALIC:
-                contentText.setTypeface(contentTitle.getTypeface(), Typeface.BOLD_ITALIC);
-                break;
-            case BOLD:
-            default:
-                contentText.setTypeface(contentTitle.getTypeface(), Typeface.BOLD);
+        if (PaperOnboardingPage.getDescriptionTextStyle() != null) {
+            switch (PaperOnboardingPage.getDescriptionTextStyle()) {
+                case NORMAL:
+                    contentText.setTypeface(contentTitle.getTypeface(), Typeface.NORMAL);
+                    break;
+                case ITALIC:
+                    contentText.setTypeface(contentTitle.getTypeface(), Typeface.ITALIC);
+                    break;
+                case BOLD_ITALIC:
+                    contentText.setTypeface(contentTitle.getTypeface(), Typeface.BOLD_ITALIC);
+                    break;
+                case BOLD:
+                default:
+                    contentText.setTypeface(contentTitle.getTypeface(), Typeface.BOLD);
+            }
+        } else {
+            contentText.setTypeface(contentTitle.getTypeface(), Typeface.BOLD);
         }
-
         return contentTextView;
     }
 
@@ -543,6 +549,10 @@ public class PaperOnboardingEngine implements PaperOnboardingEngineDefaults {
                 }
             }
         } else {
+            if (PaperOnboardingPage.getImageHeight() != 0 && PaperOnboardingPage.getImageWidth() != 0) {
+                contentIcon.setMinimumHeight(dpToPixels(PaperOnboardingPage.getImageHeight()));
+                contentIcon.setMinimumWidth(dpToPixels(PaperOnboardingPage.getImageWidth()));
+            }
             contentIcon.setImageResource(PaperOnboardingPage.getContentIconRes());
         }
 

--- a/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingPage.java
+++ b/paper-onboarding/src/main/java/com/ramotion/paperonboarding/PaperOnboardingPage.java
@@ -1,5 +1,7 @@
 package com.ramotion.paperonboarding;
 
+import com.ramotion.paperonboarding.utils.TextStyle;
+
 import java.io.Serializable;
 
 /**
@@ -13,6 +15,17 @@ public class PaperOnboardingPage implements Serializable {
     private int contentIconRes;
     private int bottomBarIconRes;
 
+    private String imageUrl;
+    private int imageHeight;
+    private int imageWidth;
+
+    private int titleTextColor;
+    private int titleTextSize;
+    private int descriptionTextColor;
+    private int descriptionTextSize;
+    private TextStyle titleTextStyle;
+    private TextStyle descriptionTextStyle;
+
     public PaperOnboardingPage() {
     }
 
@@ -22,6 +35,86 @@ public class PaperOnboardingPage implements Serializable {
         this.bottomBarIconRes = bottomBarIconRes;
         this.descriptionText = descriptionText;
         this.titleText = titleText;
+    }
+
+    public PaperOnboardingPage(String titleText, String descriptionText, String imageUrl, int bgColor, int bottomBarIconRes) {
+        this.titleText = titleText;
+        this.descriptionText = descriptionText;
+        this.bgColor = bgColor;
+        this.bottomBarIconRes = bottomBarIconRes;
+        this.imageUrl = imageUrl;
+    }
+
+    public TextStyle getTitleTextStyle() {
+        return titleTextStyle;
+    }
+
+    public void setTitleTextStyle(TextStyle titleTextStyle) {
+        this.titleTextStyle = titleTextStyle;
+    }
+
+    public TextStyle getDescriptionTextStyle() {
+        return descriptionTextStyle;
+    }
+
+    public void setDescriptionTextStyle(TextStyle descriptionTextStyle) {
+        this.descriptionTextStyle = descriptionTextStyle;
+    }
+
+    public int getTitleTextSize() {
+        return titleTextSize;
+    }
+
+    public void setTitleTextSize(int titleTextSize) {
+        this.titleTextSize = titleTextSize;
+    }
+
+    public int getDescriptionTextSize() {
+        return descriptionTextSize;
+    }
+
+    public void setDescriptionTextSize(int descriptionTextSize) {
+        this.descriptionTextSize = descriptionTextSize;
+    }
+
+    public int getTitleTextColor() {
+        return titleTextColor;
+    }
+
+    public void setTitleTextColor(int titleTextColor) {
+        this.titleTextColor = titleTextColor;
+    }
+
+    public int getDescriptionTextColor() {
+        return descriptionTextColor;
+    }
+
+    public void setDescriptionTextColor(int descriptionTextColor) {
+        this.descriptionTextColor = descriptionTextColor;
+    }
+
+    public int getImageHeight() {
+        return imageHeight;
+    }
+
+    public void setImageHeight(int imageHeight) {
+        this.imageHeight = imageHeight;
+    }
+
+    public int getImageWidth() {
+        return imageWidth;
+    }
+
+    public void setImageWidth(int imageWidth) {
+        this.imageWidth = imageWidth;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     public String getTitleText() {

--- a/paper-onboarding/src/main/java/com/ramotion/paperonboarding/utils/TextStyle.java
+++ b/paper-onboarding/src/main/java/com/ramotion/paperonboarding/utils/TextStyle.java
@@ -1,0 +1,18 @@
+package com.ramotion.paperonboarding.utils;
+
+/**
+ * TextView Text style values
+ */
+public enum TextStyle {
+
+    NORMAL(0),
+    BOLD(1),
+    ITALIC(2),
+    BOLD_ITALIC(3);
+
+    public int value;
+
+    TextStyle(int value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
Fix for issue #58

- added functionality to load image from URL using Picasso.
- added functionality to change "title text color", "description text color", "title text style", "description text style", "title text size", "description text size".
- added TextStyle.java Enum.
- added internet permission to the fragment example.
- added Picasso dependency.


Usage
```java

    PaperOnboardingPage scr1 = new PaperOnboardingPage("Hotels", "All hotels and hostels are sorted by hospitality rating",
                Color.parseColor("#678FB4"), R.drawable.hotels, R.drawable.key);

        scr1.setImageUrl("https://en.wikipedia.org/wiki/Pikachu#/media/File:Pok%C3%A9mon_Pikachu_art.png");
        scr1.setImageWidth(200);
        scr1.setImageHeight(100);
        scr1.setTitleTextColor(Color.parseColor("#FFFFFF"));
        scr1.setDescriptionTextColor(Color.parseColor("#FFFFFF"));
        scr1.setTitleTextSize(50);
        scr1.setDescriptionTextSize(30);
        scr1.setTitleTextStyle(TextStyle.BOLD_ITALIC);
        scr1.setDescriptionTextStyle(TextStyle.ITALIC);

```